### PR TITLE
Set ID to be a random string

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -21,6 +21,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 '''
 
 # Imports from python standard library
+import random
+import string
 from base64 import b64decode, b64encode
 from datetime import datetime, timezone
 from urllib.request import urlopen
@@ -786,7 +788,7 @@ class SAMLAuthenticator(Authenticator):
     def _make_authn_request(authenticator_self, element_name, handler_self):
         authn_request_text = '''<?xml version="1.0" encoding="UTF-8"?>
 <samlp:AuthnRequest  
-        ID="0" 
+        ID="{{ request_id }}" 
         Version="2.0" 
         IssueInstant="{{ issue_time }}" 
         Destination="{{ sso_login_url }}" 
@@ -799,10 +801,11 @@ class SAMLAuthenticator(Authenticator):
 
         xml_template = Template(authn_request_text)
         return xml_template.render(
-            issue_time = datetime.now().strftime(authenticator_self.time_format_string),
-            sso_login_url = authenticator_self._get_redirect_from_metadata(element_name, handler_self),
-            acs_url = authenticator_self.acs_endpoint_url,
-            audience = authenticator_self.audience
+            issue_time=datetime.now().strftime(authenticator_self.time_format_string),
+            sso_login_url=authenticator_self._get_redirect_from_metadata(element_name, handler_self),
+            acs_url=authenticator_self.acs_endpoint_url,
+            audience=authenticator_self.audience,
+            request_id=''.join(random.choice(string.ascii_letters) for _ in range(30))
         )
 
     def _make_sp_metadata(authenticator_self, meta_handler_self):


### PR DESCRIPTION
The ID element of samlp:AuthnRequest should be a valid XML ID and so it cannot start with a number or space and according to the SAML spec should contain 160 bits of random data.

https://stackoverflow.com/a/29798747/1028762

This was causing the SP-initiated flow to fail against ForgeRock.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Erik van Zijst <erik.van.zijst@gmail.com>
